### PR TITLE
Fix compilation error

### DIFF
--- a/src/Data/Graph/Interface.hs
+++ b/src/Data/Graph/Interface.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeFamilies, FlexibleContexts, UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies, FlexibleContexts, UndecidableInstances,
+   ConstrainedClassMethods #-}
 module Data.Graph.Interface (
   Vertex,
   Edge(..),


### PR DESCRIPTION
Compiling with GHC 8.10.4 gives the error:

```
src/Data/Graph/Interface.hs:206:3: error:
    • Constraint ‘Eq (EdgeLabel gr)’ in the type of ‘removeEdge’
        constrains only the class type variables
      Enable ConstrainedClassMethods to allow it
    • When checking the class method:
        removeEdge :: forall gr.
                      (MutableGraph gr, Eq (EdgeLabel gr)) =>
                      Edge gr -> gr -> gr
      In the class declaration for ‘MutableGraph’
    |
206 |   removeEdge :: (Eq (EdgeLabel gr)) => Edge gr -> gr -> gr
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```